### PR TITLE
remove non required basic auth detector plugin

### DIFF
--- a/secrets-config/.secrets-baseline
+++ b/secrets-config/.secrets-baseline
@@ -5,9 +5,6 @@
       "name": "AWSKeyDetector"
     },
     {
-      "name": "BasicAuthDetector"
-    },
-    {
       "name": "JwtTokenDetector"
     },
     {


### PR DESCRIPTION
Removing basic auth detector plugin as it is a non required at this moment