### PR TITLE
remove extra peakon dir from docker img tag

### DIFF
--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -21,7 +21,7 @@ while getopts ":p:a" opt; do
   esac
 done
 
-NAME="docker-dev-artifactory.workday.com/peakon/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}"
+NAME="docker-dev-artifactory.workday.com/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}"
 echo ${NAME}
 
 docker build -t ${NAME}:${BUILDKITE_BRANCH}-latest .


### PR DESCRIPTION
## Change

As a part of this PR https://github.com/peakon/docker-detect-secrets/pull/9, added an extra `peakon` in the image name. 
Just removing that since that value is already retrieved from `BUILDKITE_ORGANIZATION_SLUG`

